### PR TITLE
アクセストークンエラー解消

### DIFF
--- a/app/controllers/cg/users_controller.rb
+++ b/app/controllers/cg/users_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Cg::UsersController < CgLayoutsController
+  protect_from_forgery except: :pass_check
   def new
     return unless params[:cg_user].present?
 


### PR DESCRIPTION
# 概要
#30 

# 内容
ユーザーコントローラーの
pass_checkメソッドを外部からのリンク可能に設定。

[参考](https://qiita.com/ayacai115/items/ec7a621ec73692065d7a#actioncontrollerinvalidauthenticitytoken)

