### PR TITLE
page_contentが意図するレイアウトになるように修正

### DIFF
--- a/app/assets/stylesheets/cg/cg_app.scss
+++ b/app/assets/stylesheets/cg/cg_app.scss
@@ -50,11 +50,6 @@
   }
 }
 
-#page_content {
-  max-width: none;
-  width: 95%;
-}
-
 @keyframes backcoloranim-a {
   0% {
     background-color: #e8fce5;

--- a/app/assets/stylesheets/cg/layouts_default.scss
+++ b/app/assets/stylesheets/cg/layouts_default.scss
@@ -61,15 +61,12 @@ footer {
 }
 
 #page_content {
-  margin: 50px 0;
+  margin: 50px auto;
   min-height: 550px;
   height: 100%;
-  margin-left: auto;
-  margin-right: auto;
   padding: 10px;
   border-radius: 20px;
   border: solid 2px white;
-  max-width: 800px;
 }
 
 .title-logo {

--- a/app/assets/stylesheets/cg/layouts_nomal.scss
+++ b/app/assets/stylesheets/cg/layouts_nomal.scss
@@ -1,0 +1,3 @@
+#page_content {
+  max-width: 800px;
+}

--- a/app/assets/stylesheets/cg/layouts_width_stuffing.scss
+++ b/app/assets/stylesheets/cg/layouts_width_stuffing.scss
@@ -1,0 +1,4 @@
+#page_content {
+  max-width: none;
+  width: 95%;
+}


### PR DESCRIPTION
# 概要
page_contentのレイアウトが意図しているものが適用されるように変更

#112

# 内容
ログイン後のhome画面にて、page_contentが横いっぱいに広がっていたのを、
左右に余裕を持った状態で中央に配置される本来のレイアウトになるよう修正した。


@negi0109 
