### PR TITLE
サイドメニューのcssを移行

### DIFF
--- a/app/assets/stylesheets/cg/layouts_default.scss
+++ b/app/assets/stylesheets/cg/layouts_default.scss
@@ -218,3 +218,19 @@ footer {
     margin-right: 0;
   }
 }
+
+/* from _sidemenu.html.erb */
+.sidebar-nav {
+  p {
+    text-align: center;
+    text-decoration: underline;
+  }
+
+  .sidebar-brand {
+    text-align: center;
+  }
+
+  li {
+    font-size: 2rem;
+  }
+}

--- a/app/views/cg/layouts/_sidemenu.html.erb
+++ b/app/views/cg/layouts/_sidemenu.html.erb
@@ -1,18 +1,3 @@
-<style media="screen">
-  .sidebar-nav p{
-    text-align: center;
-    text-decoration: underline;
-  }
-
-  .sidebar-nav .sidebar-brand{
-    text-align: center;
-  }
-
-  .sidebar-nav li{
-    font-size: 2rem;
-  }
-</style>
-
 <ul class="sidebar-nav">
   <%= link_to root_path do %>
     <li class="sidebar-brand">


### PR DESCRIPTION
# 概要
_sidemenu.html.erbにかかれていたcssをlayout_default.scssに移行

#112 

# 内容
_sidemenu.html.erbにかかれていたcssをlayout_default.scssに移行し、scssに変更した。

@negi0109 
