### PR TITLE
サイドバーにある不要なスクロールバーを削除

### DIFF
--- a/app/assets/stylesheets/cg/layouts_default.scss
+++ b/app/assets/stylesheets/cg/layouts_default.scss
@@ -234,6 +234,7 @@ footer {
 
     #sidebar_wrapper {
       width: 250px;
+      overflow-x: hidden;
     }
 
     #page_content_wrapper {


### PR DESCRIPTION
# 概要
サイドバーにある横向きのスクロールバーを削除

#192 

# 内容
単純にスクロールバーを表示しないようにしただけです。


### スクリーンショット
![fireshot capture 16 - cutegift - http___3 112 39 126_3000_cutegift](https://user-images.githubusercontent.com/25247800/51009690-61b36280-1594-11e9-95eb-dcc523f7423a.png)

### 議題
#### サイドバーに載せる項目
- ペットリストはサイドバーにいるのか？
   - ペットショップのアカウントの場合は、サイドバーが長くなる

@Anno328 
